### PR TITLE
Add practice hub, fill-in-blank, roadmap course switcher, home preview

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -56,7 +56,7 @@ export default function AppLayout({
             <Link
               to="/roadmap"
               className={`flex items-center gap-3.5 px-4 py-3 rounded-xl transition-all group ${
-                location.pathname === '/roadmap'
+                location.pathname.startsWith('/roadmap')
                   ? 'bg-primary/10 dark:bg-primary/20 border-l-4 border-primary text-primary shadow-sm'
                   : 'text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800'
               }`}

--- a/frontend/src/components/IncomeStatementPracticeCell.tsx
+++ b/frontend/src/components/IncomeStatementPracticeCell.tsx
@@ -1,0 +1,272 @@
+import LearningFillBlank, { gradeFillBlankAnswer } from './LearningFillBlank'
+import LearningFlashcard from './LearningFlashcard'
+import LearningMcq from './LearningMcq'
+
+export type IncomePracticeType = 'open' | 'flashcard' | 'mcq' | 'fill'
+
+export type OpenPracticeFeedback = 'idle' | 'correct' | 'incorrect'
+
+const PRACTICE_TYPE_OPTIONS: { value: IncomePracticeType; label: string }[] = [
+  { value: 'open', label: 'Open-ended (chat)' },
+  { value: 'fill', label: 'Fill in the blank' },
+  { value: 'flashcard', label: 'Flashcard' },
+  { value: 'mcq', label: 'Multiple choice' },
+]
+
+const INCOME_FILL_BANK = ['expenses', 'assets', 'liabilities', 'dividends']
+
+type IncomeStatementPracticeCellProps = {
+  practiceType: IncomePracticeType
+  onPracticeTypeChange: (t: IncomePracticeType) => void
+  openFeedback: OpenPracticeFeedback
+  onResetOpenPractice: () => void
+  fillFeedback: OpenPracticeFeedback
+  fillResetKey: number
+  onFillResult: (result: 'correct' | 'incorrect') => void
+  onResetFillPractice: () => void
+}
+
+/** Chat grading for the income-statement fill-in (missing word: expenses). */
+export function gradeIncomeStatementFillBlank(answer: string): boolean {
+  return gradeFillBlankAnswer('expenses', answer)
+}
+
+/** Mock grader for the coffee shop scenario (net income = $30,000). */
+export function gradeCoffeeShopNetIncome(answer: string): boolean {
+  const raw = answer.trim().toLowerCase()
+  const noComma = raw.replace(/,/g, '')
+  const compact = noComma.replace(/\$/g, '').replace(/\s+/g, ' ')
+
+  if (/\b30000\b/.test(compact)) return true
+  if (/\b30\s*000\b/.test(compact)) return true
+  if (/\b30k\b/.test(raw.replace(/\s/g, ''))) return true
+  if (noComma.includes('30000')) return true
+  if (/thirty\s*thousand/.test(raw)) return true
+  if (/(\$|^|\s)30(\.0+)?\s*k\b/.test(raw)) return true
+
+  return false
+}
+
+export default function IncomeStatementPracticeCell({
+  practiceType,
+  onPracticeTypeChange,
+  openFeedback,
+  onResetOpenPractice,
+  fillFeedback,
+  fillResetKey,
+  onFillResult,
+  onResetFillPractice,
+}: IncomeStatementPracticeCellProps) {
+  return (
+    <section className="rounded-2xl bg-gradient-to-br from-amber-50 to-emerald-50 dark:from-amber-950/30 dark:to-emerald-950/20 p-6 border-2 border-amber-200/80 dark:border-amber-800/40 shadow-soft">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between mb-4 min-w-0">
+        <h3 className="text-lg font-bold text-slate-900 dark:text-white font-display flex items-center gap-2 shrink-0">
+          <span className="material-symbols-outlined text-primary" aria-hidden>
+            edit
+          </span>
+          Try it yourself
+        </h3>
+        <div className="flex flex-col gap-1 w-full sm:w-auto sm:min-w-[13.5rem] shrink-0">
+          <label htmlFor="income-practice-type" className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+            Question type
+          </label>
+          <select
+            id="income-practice-type"
+            value={practiceType}
+            onChange={(e) => onPracticeTypeChange(e.target.value as IncomePracticeType)}
+            className="rounded-xl border-2 border-amber-200/90 dark:border-amber-800/50 bg-white dark:bg-slate-900 px-3 py-2 text-sm font-semibold text-slate-800 dark:text-slate-100 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 cursor-pointer"
+          >
+            {PRACTICE_TYPE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {practiceType === 'open' && (
+        <div className="space-y-4">
+          <p className="text-slate-600 dark:text-slate-300 leading-relaxed">
+            Imagine a coffee shop makes <strong className="text-slate-900 dark:text-white">$200,000</strong> in revenue
+            this year. Their costs include:
+          </p>
+          <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 space-y-1">
+            <li>Coffee beans and supplies: $60,000</li>
+            <li>Staff wages: $80,000</li>
+            <li>Rent and utilities: $30,000</li>
+          </ul>
+          <p className="text-slate-600 dark:text-slate-300">
+            What&apos;s their net income? Type your answer in the chat below.
+          </p>
+
+          {openFeedback === 'correct' && (
+            <div
+              className="rounded-xl border-2 border-primary/40 bg-emerald-50/90 dark:bg-emerald-950/30 px-4 py-3 text-sm text-slate-800 dark:text-slate-100"
+              role="status"
+            >
+              <p className="font-bold text-primary dark:text-primary-light mb-1">Nice work — that&apos;s right!</p>
+              <p className="text-slate-700 dark:text-slate-300">
+                Net income is <strong className="text-slate-900 dark:text-white">$30,000</strong> ($200,000 revenue minus
+                $170,000 in total expenses).
+              </p>
+              <button
+                type="button"
+                onClick={onResetOpenPractice}
+                className="mt-3 text-sm font-semibold text-primary hover:underline"
+              >
+                Try another
+              </button>
+            </div>
+          )}
+
+          {openFeedback === 'incorrect' && (
+            <div
+              className="rounded-xl border-2 border-amber-600/40 dark:border-amber-500/40 bg-amber-50/80 dark:bg-amber-950/25 px-4 py-3 text-sm text-slate-800 dark:text-slate-100"
+              role="status"
+            >
+              <p className="font-bold text-amber-900 dark:text-amber-200 mb-1">Not quite — give it another shot</p>
+              <p className="text-slate-700 dark:text-slate-300">
+                Add up the expenses, subtract from revenue, or type the net income number. You can ask again in the chat whenever you&apos;re ready.
+              </p>
+              <button
+                type="button"
+                onClick={onResetOpenPractice}
+                className="mt-3 text-sm font-semibold text-primary hover:underline"
+              >
+                Reset and try again
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {practiceType === 'fill' && (
+        <div className="space-y-4">
+          {(fillFeedback === 'idle' || fillFeedback === 'incorrect') && (
+            <>
+              <LearningFillBlank
+                wordBank={INCOME_FILL_BANK}
+                correctAnswer="expenses"
+                resetKey={fillResetKey}
+                onCorrect={() => onFillResult('correct')}
+                onIncorrect={() => onFillResult('incorrect')}
+                before={
+                  <>
+                    On a basic income statement, <strong className="text-slate-900 dark:text-white">net income</strong>{' '}
+                    equals revenue minus total
+                  </>
+                }
+                after={<>.</>}
+              />
+              <p className="text-slate-600 dark:text-slate-300 text-sm">
+                Drag the correct answer or type in chat.
+              </p>
+            </>
+          )}
+
+          {fillFeedback === 'correct' && (
+            <div
+              className="rounded-xl border-2 border-primary/40 bg-emerald-50/90 dark:bg-emerald-950/30 px-4 py-3 text-sm text-slate-800 dark:text-slate-100"
+              role="status"
+            >
+              <p className="font-bold text-primary dark:text-primary-light mb-1">Correct!</p>
+              <p className="text-slate-700 dark:text-slate-300">
+                Net income is revenue minus total <strong className="text-slate-900 dark:text-white">expenses</strong>{' '}
+                for the period.
+              </p>
+              <button
+                type="button"
+                onClick={onResetFillPractice}
+                className="mt-3 text-sm font-semibold text-primary hover:underline"
+              >
+                Try again
+              </button>
+            </div>
+          )}
+
+          {fillFeedback === 'incorrect' && (
+            <div
+              className="rounded-xl border-2 border-amber-600/40 dark:border-amber-500/40 bg-amber-50/80 dark:bg-amber-950/25 px-4 py-3 text-sm text-slate-800 dark:text-slate-100"
+              role="status"
+            >
+              <p className="font-bold text-amber-900 dark:text-amber-200 mb-1">Not quite</p>
+              <p className="text-slate-700 dark:text-slate-300">
+                Try another word from the bank, or type <strong className="text-slate-900 dark:text-white">expenses</strong> in
+                the chat.
+              </p>
+              <button
+                type="button"
+                onClick={onResetFillPractice}
+                className="mt-3 text-sm font-semibold text-primary hover:underline"
+              >
+                Reset and try again
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {practiceType === 'flashcard' && (
+        <div className="space-y-2">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Flip the card to check your recall — no chat needed for this mode.
+          </p>
+          <LearningFlashcard
+            embedded
+            front={
+              <>
+                <p className="text-slate-800 dark:text-slate-100 font-display font-bold text-base mb-1">Question</p>
+                <p>
+                  On a simple income statement, how do you get from{' '}
+                  <strong className="text-slate-900 dark:text-white">total revenue</strong> to{' '}
+                  <strong className="text-slate-900 dark:text-white">net income</strong>?
+                </p>
+              </>
+            }
+            back={
+              <>
+                <p className="text-slate-800 dark:text-slate-100 font-display font-bold text-base mb-1">Answer</p>
+                <p>
+                  Subtract <strong className="text-slate-900 dark:text-white">total expenses</strong> from revenue for the
+                  same period. What is left is net income: profit if positive, a loss if negative.
+                </p>
+              </>
+            }
+          />
+        </div>
+      )}
+
+      {practiceType === 'mcq' && (
+        <div className="space-y-2">
+          <p className="text-sm text-slate-600 dark:text-slate-400">Tap an option — feedback appears instantly below.</p>
+          <LearningMcq
+            embedded
+            key="income-mcq"
+            question={
+              <p>
+                On a standard income statement shown to investors, which line best describes{' '}
+                <strong className="text-slate-900 dark:text-white">profit after all expenses</strong> for the reporting
+                period?
+              </p>
+            }
+            options={[
+              { id: 'rev', label: 'Gross revenue' },
+              { id: 'cogs', label: 'Cost of goods sold only' },
+              { id: 'ni', label: 'Net income' },
+              { id: 'cash', label: 'Cash on hand at year-end' },
+            ]}
+            correctOptionId="ni"
+            explanation={
+              <>
+                <strong className="text-slate-800 dark:text-slate-200">Net income</strong> is often called the bottom line:
+                revenue minus all expenses for that period. It is not the same as cash in the bank (that&apos;s on the
+                balance sheet and cash flow statement).
+              </>
+            }
+          />
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/LearningFillBlank.tsx
+++ b/frontend/src/components/LearningFillBlank.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState, type DragEvent, type ReactNode } from 'react'
+
+type LearningFillBlankProps = {
+  /** Words available to move into the blank (shown as chips). */
+  wordBank: string[]
+  correctAnswer: string
+  /** Content before the blank (inline). */
+  before: ReactNode
+  /** Content after the blank (inline). */
+  after?: ReactNode
+  /** Bump to reset chips + blank (e.g. try again). */
+  resetKey: number
+  onCorrect: () => void
+  onIncorrect: () => void
+}
+
+export function gradeFillBlankAnswer(correctAnswer: string, reply: string): boolean {
+  const t = reply.trim().toLowerCase().replace(/\s+/g, ' ')
+  const target = correctAnswer.trim().toLowerCase()
+  const esc = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`\\b${esc}\\b`, 'i').test(t)
+}
+
+export default function LearningFillBlank({
+  wordBank: wordBankProp,
+  correctAnswer,
+  before,
+  after,
+  resetKey,
+  onCorrect,
+  onIncorrect,
+}: LearningFillBlankProps) {
+  const [bank, setBank] = useState<string[]>(() => [...wordBankProp])
+  const [blank, setBlank] = useState<string | null>(null)
+
+  useEffect(() => {
+    setBank([...wordBankProp])
+    setBlank(null)
+  }, [resetKey, wordBankProp])
+
+  const returnToBank = useCallback((w: string) => {
+    setBank((b) => (b.includes(w) ? b : [...b, w]))
+  }, [])
+
+  const commitBlank = useCallback(
+    (w: string) => {
+      const normalized = w.trim().toLowerCase()
+      if (blank === w) return
+
+      const prev = blank
+      if (prev && prev !== w) returnToBank(prev)
+
+      setBank((b) => b.filter((x) => x !== w))
+      setBlank(w)
+
+      if (normalized === correctAnswer.trim().toLowerCase()) {
+        onCorrect()
+        return
+      }
+
+      onIncorrect()
+      window.setTimeout(() => {
+        setBlank(null)
+        setBank([...wordBankProp])
+      }, 1800)
+    },
+    [blank, correctAnswer, onCorrect, onIncorrect, returnToBank, wordBankProp]
+  )
+
+  const clearBlank = useCallback(() => {
+    if (!blank) return
+    returnToBank(blank)
+    setBlank(null)
+  }, [blank, returnToBank])
+
+  const handleDragStart = (e: DragEvent, word: string) => {
+    e.dataTransfer.setData('text/plain', word)
+    e.dataTransfer.effectAllowed = 'move'
+  }
+
+  const handleDropZoneDragOver = (e: DragEvent) => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+  }
+
+  const handleDropZoneDrop = (e: DragEvent) => {
+    e.preventDefault()
+    const w = e.dataTransfer.getData('text/plain').trim()
+    if (!w || !wordBankProp.includes(w)) return
+    commitBlank(w)
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-slate-700 dark:text-slate-200 leading-relaxed text-base">
+        {before}{' '}
+        <span
+          role="button"
+          tabIndex={0}
+          onDragOver={handleDropZoneDragOver}
+          onDrop={handleDropZoneDrop}
+          onClick={clearBlank}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              clearBlank()
+            }
+          }}
+          className={`inline-flex min-w-[7rem] align-baseline justify-center px-2 py-0.5 mx-0.5 rounded-lg border-2 border-dashed transition-colors ${
+            blank
+              ? 'border-primary bg-emerald-50/90 dark:bg-emerald-950/40 text-slate-900 dark:text-white font-semibold cursor-pointer'
+              : 'border-amber-400/70 dark:border-amber-600/50 bg-amber-50/40 dark:bg-amber-950/20 text-slate-500 dark:text-slate-400'
+          }`}
+          aria-label={blank ? `Filled with ${blank}. Click to clear.` : 'Drop zone for answer'}
+        >
+          {blank ?? '—'}
+        </span>{' '}
+        {after}
+      </p>
+
+      <div>
+        <p className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-2">Word bank</p>
+        <div className="flex flex-wrap gap-2">
+          {bank.map((w) => (
+            <button
+              key={w}
+              type="button"
+              draggable
+              onDragStart={(e) => handleDragStart(e, w)}
+              onClick={() => commitBlank(w)}
+              className="rounded-xl border-2 border-amber-200/90 dark:border-amber-800/50 bg-white dark:bg-slate-800 px-3 py-2 text-sm font-semibold text-slate-800 dark:text-slate-100 shadow-sm cursor-grab active:cursor-grabbing hover:border-primary/50 hover:bg-amber-50/50 dark:hover:bg-slate-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/LearningFlashcard.tsx
+++ b/frontend/src/components/LearningFlashcard.tsx
@@ -1,0 +1,69 @@
+import { useState, type ReactNode } from 'react'
+
+type LearningFlashcardProps = {
+  /** Section heading when `embedded` is false */
+  title?: string
+  icon?: string
+  front: ReactNode
+  back: ReactNode
+  hintFront?: string
+  hintBack?: string
+  /** Omit outer section + title — use inside a parent practice card */
+  embedded?: boolean
+}
+
+export default function LearningFlashcard({
+  title = 'Quick flashcard',
+  icon = 'flip_to_back',
+  front,
+  back,
+  hintFront = 'Click the card to reveal the answer',
+  hintBack = 'Click again to see the question',
+  embedded = false,
+}: LearningFlashcardProps) {
+  const [flipped, setFlipped] = useState(false)
+
+  const flipBody = (
+      <button
+        type="button"
+        onClick={() => setFlipped((f) => !f)}
+        aria-pressed={flipped}
+        className={`w-full text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 [perspective:1200px] ${
+          embedded
+            ? 'focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900/85'
+            : 'focus-visible:ring-offset-amber-50 dark:focus-visible:ring-offset-slate-900'
+        }`}
+      >
+        <div
+          className={`relative min-h-[13rem] sm:min-h-[11rem] w-full transition-transform duration-500 ease-out [transform-style:preserve-3d] motion-reduce:transition-none ${
+            flipped ? '[transform:rotateY(180deg)]' : ''
+          }`}
+        >
+          <div className="absolute inset-0 flex flex-col justify-center rounded-xl border border-amber-200/70 dark:border-amber-800/50 bg-white/85 dark:bg-slate-900/85 px-4 py-5 sm:px-6 sm:py-6 [backface-visibility:hidden] shadow-sm">
+            <div className="text-slate-700 dark:text-slate-200 leading-relaxed">{front}</div>
+            <p className="mt-4 text-xs font-semibold text-primary dark:text-primary-light/90">{hintFront}</p>
+          </div>
+          <div className="absolute inset-0 flex flex-col justify-center rounded-xl border border-amber-200/70 dark:border-amber-800/50 bg-white/85 dark:bg-slate-900/85 px-4 py-5 sm:px-6 sm:py-6 [backface-visibility:hidden] [transform:rotateY(180deg)] shadow-sm">
+            <div className="text-slate-700 dark:text-slate-200 leading-relaxed">{back}</div>
+            <p className="mt-4 text-xs font-semibold text-primary dark:text-primary-light/90">{hintBack}</p>
+          </div>
+        </div>
+      </button>
+  )
+
+  if (embedded) {
+    return flipBody
+  }
+
+  return (
+    <section className="rounded-2xl bg-gradient-to-br from-amber-50 to-amber-100/50 dark:from-amber-950/25 dark:to-amber-950/10 p-6 sm:p-8 border-2 border-amber-200/80 dark:border-amber-800/40 shadow-soft">
+      <h3 className="text-lg font-bold text-primary font-display mb-4 flex items-center gap-2">
+        <span className="material-symbols-outlined text-primary shrink-0" aria-hidden>
+          {icon}
+        </span>
+        {title}
+      </h3>
+      {flipBody}
+    </section>
+  )
+}

--- a/frontend/src/components/LearningMcq.tsx
+++ b/frontend/src/components/LearningMcq.tsx
@@ -1,0 +1,139 @@
+import { useId, useState, type ReactNode } from 'react'
+
+export type LearningMcqOption = {
+  id: string
+  label: ReactNode
+}
+
+type LearningMcqProps = {
+  title?: string
+  icon?: string
+  question: ReactNode
+  options: LearningMcqOption[]
+  correctOptionId: string
+  /** Shown after the learner picks an answer */
+  explanation?: ReactNode
+  embedded?: boolean
+}
+
+export default function LearningMcq({
+  title = 'Check your understanding',
+  icon = 'quiz',
+  question,
+  options,
+  correctOptionId,
+  explanation,
+  embedded = false,
+}: LearningMcqProps) {
+  const baseId = useId()
+  const questionId = `${baseId}-question`
+  const [chosen, setChosen] = useState<string | null>(null)
+  const answered = chosen !== null
+
+  const tryAgain = () => setChosen(null)
+
+  const inner = (
+      <div
+        className="rounded-xl border border-amber-200/70 dark:border-amber-800/50 bg-white/85 dark:bg-slate-900/85 px-4 py-5 sm:px-6 sm:py-6 shadow-sm space-y-4"
+        role="radiogroup"
+        aria-labelledby={questionId}
+      >
+        <div id={questionId} className="text-slate-700 dark:text-slate-200 leading-relaxed">
+          {question}
+        </div>
+
+        <ul className="space-y-2 list-none p-0 m-0">
+          {options.map((opt) => {
+            const picked = chosen === opt.id
+            const isCorrectOpt = opt.id === correctOptionId
+            let optionClass =
+              'w-full text-left rounded-xl border-2 px-4 py-3 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 '
+
+            if (!answered) {
+              optionClass +=
+                'border-amber-200/80 dark:border-amber-800/40 bg-white dark:bg-slate-800/50 text-slate-800 dark:text-slate-100 hover:border-primary/50 hover:bg-amber-50/50 dark:hover:bg-slate-800 cursor-pointer'
+            } else {
+              if (isCorrectOpt) {
+                optionClass +=
+                  'border-primary bg-emerald-50 dark:bg-emerald-950/35 text-slate-900 dark:text-white ring-2 ring-primary/30'
+              } else if (picked) {
+                optionClass += 'border-red-400 dark:border-red-500 bg-red-50/90 dark:bg-red-950/25 text-slate-900 dark:text-slate-100'
+              } else {
+                optionClass +=
+                  'border-slate-200/80 dark:border-slate-600 bg-slate-50/80 dark:bg-slate-800/40 text-slate-500 dark:text-slate-400 opacity-80'
+              }
+            }
+
+            return (
+              <li key={opt.id}>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={picked}
+                  disabled={answered}
+                  onClick={() => {
+                    if (!answered) setChosen(opt.id)
+                  }}
+                  className={optionClass}
+                >
+                  {opt.label}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+
+        {answered && (
+          <div
+            className="space-y-2 pt-1 border-t border-amber-200/50 dark:border-amber-800/40"
+            role="status"
+          >
+            <p
+              className={`font-display font-extrabold text-lg ${
+                chosen === correctOptionId
+                  ? 'text-primary dark:text-primary-light'
+                  : 'text-amber-800 dark:text-amber-200'
+              }`}
+            >
+              {chosen === correctOptionId ? 'Correct!' : 'Not quite.'}
+            </p>
+            {explanation && (
+              <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">{explanation}</p>
+            )}
+          </div>
+        )}
+
+        {answered && (
+          <div className="pt-1">
+            <button
+              type="button"
+              onClick={tryAgain}
+              className="text-sm font-semibold text-primary hover:underline"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        {!answered && (
+          <p className="text-xs font-semibold text-primary dark:text-primary-light/90">Choose an answer</p>
+        )}
+      </div>
+  )
+
+  if (embedded) {
+    return inner
+  }
+
+  return (
+    <section className="rounded-2xl bg-gradient-to-br from-amber-50 to-amber-100/50 dark:from-amber-950/25 dark:to-amber-950/10 p-6 sm:p-8 border-2 border-amber-200/80 dark:border-amber-800/40 shadow-soft">
+      <h3 className="text-lg font-bold text-primary font-display mb-4 flex items-center gap-2">
+        <span className="material-symbols-outlined text-primary shrink-0" aria-hidden>
+          {icon}
+        </span>
+        {title}
+      </h3>
+      {inner}
+    </section>
+  )
+}

--- a/frontend/src/components/LearningRoadmap.tsx
+++ b/frontend/src/components/LearningRoadmap.tsx
@@ -1,50 +1,79 @@
 import { Link } from 'react-router-dom'
+import { useEffect, useRef } from 'react'
+import type { HomeRoadmapOutcome } from '../data/homeRoadmapPreview'
 
-const OUTCOMES = [
+const DEFAULT_OUTCOMES: HomeRoadmapOutcome[] = [
   {
     id: '1',
     title: 'Reading a Financial Statement',
-    status: 'completed' as const,
+    status: 'completed',
   },
   {
     id: '2',
     title: 'The Income Statement',
-    status: 'current' as const,
+    status: 'current',
     subtext: 'Based on your background, this is the right place to start.',
   },
   {
     id: '3',
     title: 'The Balance Sheet',
-    status: 'upcoming' as const,
+    status: 'upcoming',
   },
   {
     id: '4',
     title: 'Cash Flow Basics',
-    status: 'upcoming' as const,
+    status: 'upcoming',
   },
   {
     id: '5',
     title: 'Ratio Analysis',
-    status: 'upcoming' as const,
+    status: 'upcoming',
   },
   {
     id: '6',
     title: 'Interpreting Performance',
-    status: 'upcoming' as const,
+    status: 'upcoming',
   },
 ]
 
 type LearningRoadmapProps = {
   compact?: boolean
   showViewFullLink?: boolean
+  /** When true, list is capped in height and scrolls; current step is scrolled into view. */
+  scrollable?: boolean
+  outcomes?: HomeRoadmapOutcome[]
+  startHereTo?: string
+  viewFullTo?: string
 }
 
-export default function LearningRoadmap({ compact, showViewFullLink }: LearningRoadmapProps) {
-  return (
+export default function LearningRoadmap({
+  compact,
+  showViewFullLink,
+  scrollable,
+  outcomes: outcomesProp,
+  startHereTo = '/module/income-statement',
+  viewFullTo = '/roadmap',
+}: LearningRoadmapProps) {
+  const outcomes = outcomesProp ?? DEFAULT_OUTCOMES
+  const currentItemRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!scrollable || !currentItemRef.current) return
+    const id = requestAnimationFrame(() => {
+      currentItemRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    })
+    return () => cancelAnimationFrame(id)
+  }, [scrollable, outcomes])
+
+  const list = (
     <div className="relative pl-1">
       <div className="absolute left-[11px] top-8 bottom-8 w-0 border-l-2 border-dashed border-slate-300 dark:border-slate-600" />
-      {OUTCOMES.map((outcome) => (
-        <div key={outcome.id} className={`relative flex gap-6 ${compact ? 'pb-6 last:pb-0' : 'pb-10 last:pb-0'}`}>
+      {outcomes.map((outcome) => (
+        <div
+          key={outcome.id}
+          ref={outcome.status === 'current' ? currentItemRef : undefined}
+          className={`relative flex gap-6 ${compact ? 'pb-6 last:pb-0' : 'pb-10 last:pb-0'}`}
+        >
           <div
             className={`relative z-10 flex shrink-0 items-center justify-center rounded-full ${
               outcome.status === 'completed'
@@ -82,7 +111,7 @@ export default function LearningRoadmap({ compact, showViewFullLink }: LearningR
               </div>
               {outcome.status === 'current' && (
                 <Link
-                  to="/module/income-statement"
+                  to={startHereTo}
                   className="shrink-0 rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white hover:bg-primary-light transition-all shadow-md shadow-primary/20 inline-block"
                 >
                   Start here
@@ -92,10 +121,22 @@ export default function LearningRoadmap({ compact, showViewFullLink }: LearningR
           </div>
         </div>
       ))}
+    </div>
+  )
+
+  return (
+    <div>
+      {scrollable ? (
+        <div className="max-h-[min(11rem,27vh)] overflow-y-auto overscroll-y-contain scroll-smooth rounded-xl border border-emerald-200/60 dark:border-emerald-800/40 bg-stone-50/50 dark:bg-slate-950/30 px-3 py-2 sm:px-4">
+          {list}
+        </div>
+      ) : (
+        list
+      )}
       {showViewFullLink && (
-        <div className="mt-6 pl-8">
+        <div className={`mt-6 pl-8 ${scrollable ? 'border-t border-emerald-200/40 dark:border-emerald-800/30 pt-4' : ''}`}>
           <Link
-            to="/roadmap"
+            to={viewFullTo}
             className="text-sm font-semibold text-primary hover:underline inline-flex items-center gap-1"
           >
             View full roadmap

--- a/frontend/src/components/RoadmapCourseSelect.tsx
+++ b/frontend/src/components/RoadmapCourseSelect.tsx
@@ -1,0 +1,83 @@
+import { useNavigate, useLocation } from 'react-router-dom'
+
+export const ROADMAP_COURSES = [
+  { path: '/roadmap', label: 'ACCY 301 · Financial Accounting' },
+  { path: '/roadmap/cs101', label: 'CS 101 · Intro to Python' },
+  { path: '/roadmap/mktg440', label: 'MKTG 440 · Digital Marketing' },
+  { path: '/roadmap/hist102', label: 'HIST 102 · World History II' },
+  { path: '/roadmap/econ201', label: 'ECON 201 · Macroeconomics' },
+] as const
+
+type RoadmapCourseSelectProps = {
+  /** Compact styling for PageHeader (green gradient bar) */
+  variant?: 'page' | 'header'
+  value?: string
+  onValueChange?: (path: string) => void
+  className?: string
+  selectId?: string
+}
+
+export default function RoadmapCourseSelect({
+  variant = 'page',
+  value: controlledValue,
+  onValueChange,
+  className: rootClassName,
+  selectId,
+}: RoadmapCourseSelectProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const isControlled = controlledValue !== undefined && onValueChange !== undefined
+
+  const value = isControlled
+    ? controlledValue
+    : (ROADMAP_COURSES.find((c) => c.path === location.pathname)?.path ?? '/roadmap')
+
+  const isHeader = variant === 'header'
+  const selectDomId = selectId ?? (isControlled ? 'roadmap-course-home' : 'roadmap-course')
+
+  return (
+    <div
+      className={`${isHeader ? '' : isControlled ? 'mb-0' : 'mb-8'} ${rootClassName ?? ''}`.trim()}
+    >
+      <label htmlFor={selectDomId} className="sr-only">
+        Choose course roadmap
+      </label>
+      <div
+        className={
+          isHeader
+            ? 'flex flex-col sm:flex-row sm:items-center gap-2 w-full md:w-auto md:min-w-[260px] max-w-md'
+            : 'flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4'
+        }
+      >
+        <span
+          className={
+            isHeader
+              ? 'sr-only'
+              : 'text-sm font-semibold text-slate-600 dark:text-slate-400 shrink-0'
+          }
+        >
+          Course
+        </span>
+        <select
+          id={selectDomId}
+          value={value}
+          onChange={(e) =>
+            isControlled ? onValueChange(e.target.value) : navigate(e.target.value)
+          }
+          className={
+            isHeader
+              ? 'w-full rounded-xl border border-emerald-800/20 dark:border-white/25 bg-white/90 dark:bg-slate-900/75 backdrop-blur-sm px-3 py-2.5 text-sm font-semibold text-slate-900 dark:text-white shadow-sm focus:border-primary dark:focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/25 cursor-pointer'
+              : 'w-full sm:max-w-md rounded-xl border-2 border-primary/20 dark:border-primary/30 bg-white dark:bg-slate-800 px-4 py-3 text-sm font-semibold text-slate-900 dark:text-white shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 cursor-pointer'
+          }
+        >
+          {ROADMAP_COURSES.map((course) => (
+            <option key={course.path} value={course.path}>
+              {course.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/data/homeRoadmapPreview.ts
+++ b/frontend/src/data/homeRoadmapPreview.ts
@@ -1,0 +1,112 @@
+export type HomeRoadmapOutcome = {
+  id: string
+  title: string
+  status: 'completed' | 'current' | 'upcoming'
+  subtext?: string
+}
+
+export type HomeRoadmapPreview = {
+  cardTitle: string
+  cardSubtitle: string
+  outcomes: HomeRoadmapOutcome[]
+  startHerePath: string
+  fullRoadmapPath: string
+}
+
+export const HOME_ROADMAP_PREVIEW: Record<string, HomeRoadmapPreview> = {
+  '/roadmap': {
+    cardTitle: 'Financial Accounting Roadmap',
+    cardSubtitle: '6 learning outcomes · Personalized for you',
+    outcomes: [
+      { id: '1', title: 'Reading a Financial Statement', status: 'completed' },
+      {
+        id: '2',
+        title: 'The Income Statement',
+        status: 'current',
+        subtext: 'Based on your background, this is the right place to start.',
+      },
+      { id: '3', title: 'The Balance Sheet', status: 'upcoming' },
+      { id: '4', title: 'Cash Flow Basics', status: 'upcoming' },
+      { id: '5', title: 'Ratio Analysis', status: 'upcoming' },
+      { id: '6', title: 'Interpreting Performance', status: 'upcoming' },
+    ],
+    startHerePath: '/module/income-statement',
+    fullRoadmapPath: '/roadmap',
+  },
+  '/roadmap/cs101': {
+    cardTitle: 'Intro to Python Roadmap',
+    cardSubtitle: '6 learning outcomes · Personalized for you',
+    outcomes: [
+      { id: '1', title: 'Python Basics & Syntax', status: 'completed' },
+      {
+        id: '2',
+        title: 'Variables and Data Types',
+        status: 'current',
+        subtext: 'Learn about integers, strings, booleans, and type conversion.',
+      },
+      { id: '3', title: 'Control Flow', status: 'upcoming' },
+      { id: '4', title: 'Functions and Modules', status: 'upcoming' },
+      { id: '5', title: 'Data Structures', status: 'upcoming' },
+      { id: '6', title: 'File I/O and Error Handling', status: 'upcoming' },
+    ],
+    startHerePath: '/module/cs101-variables',
+    fullRoadmapPath: '/roadmap/cs101',
+  },
+  '/roadmap/mktg440': {
+    cardTitle: 'Digital Marketing Roadmap',
+    cardSubtitle: '6 learning outcomes · Personalized for you',
+    outcomes: [
+      { id: '1', title: 'Digital Marketing Fundamentals', status: 'completed' },
+      {
+        id: '2',
+        title: 'SEO Basics',
+        status: 'current',
+        subtext: 'Master search engine optimization and content discovery.',
+      },
+      { id: '3', title: 'Social Media Strategy', status: 'upcoming' },
+      { id: '4', title: 'Email Marketing', status: 'upcoming' },
+      { id: '5', title: 'Analytics and Metrics', status: 'upcoming' },
+      { id: '6', title: 'Campaign Optimization', status: 'upcoming' },
+    ],
+    startHerePath: '/module/mktg440-seo',
+    fullRoadmapPath: '/roadmap/mktg440',
+  },
+  '/roadmap/hist102': {
+    cardTitle: 'World History II Roadmap',
+    cardSubtitle: '6 learning outcomes · Personalized for you',
+    outcomes: [
+      { id: '1', title: 'Age of Revolutions', status: 'completed' },
+      {
+        id: '2',
+        title: 'Industrial Revolution',
+        status: 'current',
+        subtext: 'Explore the transformation of society through industrialization.',
+      },
+      { id: '3', title: 'World War I', status: 'upcoming' },
+      { id: '4', title: 'World War II', status: 'upcoming' },
+      { id: '5', title: 'Cold War Era', status: 'upcoming' },
+      { id: '6', title: 'Modern Globalization', status: 'upcoming' },
+    ],
+    startHerePath: '/module/hist102-industrial',
+    fullRoadmapPath: '/roadmap/hist102',
+  },
+  '/roadmap/econ201': {
+    cardTitle: 'Macroeconomics Roadmap',
+    cardSubtitle: '6 learning outcomes · Personalized for you',
+    outcomes: [
+      { id: '1', title: 'Economic Foundations', status: 'completed' },
+      {
+        id: '2',
+        title: 'GDP and National Income',
+        status: 'current',
+        subtext: 'Understanding how we measure economic output and growth.',
+      },
+      { id: '3', title: 'Inflation and Price Indices', status: 'upcoming' },
+      { id: '4', title: 'Unemployment and Labor Markets', status: 'upcoming' },
+      { id: '5', title: 'Monetary Policy', status: 'upcoming' },
+      { id: '6', title: 'Fiscal Policy', status: 'upcoming' },
+    ],
+    startHerePath: '/module/econ201-gdp',
+    fullRoadmapPath: '/roadmap/econ201',
+  },
+}

--- a/frontend/src/pages/CS101RoadmapPage.tsx
+++ b/frontend/src/pages/CS101RoadmapPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import AppLayout from '../components/AppLayout'
 import CS101Roadmap from '../components/CS101Roadmap'
+import RoadmapCourseSelect from '../components/RoadmapCourseSelect'
 
 export default function CS101RoadmapPage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -14,6 +15,7 @@ export default function CS101RoadmapPage() {
       onToggleSettings={() => setSettingsOpen(!settingsOpen)}
       title="Intro to Python"
       description="6 learning outcomes · Personalized for you"
+      action={<RoadmapCourseSelect variant="header" />}
     >
       <div className="max-w-[800px] w-full min-w-0 mx-auto px-8 lg:px-12 py-8 lg:py-12">
         <CS101Roadmap />

--- a/frontend/src/pages/ECON201RoadmapPage.tsx
+++ b/frontend/src/pages/ECON201RoadmapPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import AppLayout from '../components/AppLayout'
 import ECON201Roadmap from '../components/ECON201Roadmap'
+import RoadmapCourseSelect from '../components/RoadmapCourseSelect'
 
 export default function ECON201RoadmapPage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -14,6 +15,7 @@ export default function ECON201RoadmapPage() {
       onToggleSettings={() => setSettingsOpen(!settingsOpen)}
       title="Macroeconomics"
       description="6 learning outcomes · Personalized for you"
+      action={<RoadmapCourseSelect variant="header" />}
     >
       <div className="max-w-[800px] w-full min-w-0 mx-auto px-8 lg:px-12 py-8 lg:py-12">
         <ECON201Roadmap />

--- a/frontend/src/pages/HIST102RoadmapPage.tsx
+++ b/frontend/src/pages/HIST102RoadmapPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import AppLayout from '../components/AppLayout'
 import HIST102Roadmap from '../components/HIST102Roadmap'
+import RoadmapCourseSelect from '../components/RoadmapCourseSelect'
 
 export default function HIST102RoadmapPage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -14,6 +15,7 @@ export default function HIST102RoadmapPage() {
       onToggleSettings={() => setSettingsOpen(!settingsOpen)}
       title="World History II"
       description="6 learning outcomes · Personalized for you"
+      action={<RoadmapCourseSelect variant="header" />}
     >
       <div className="max-w-[800px] w-full min-w-0 mx-auto px-8 lg:px-12 py-8 lg:py-12">
         <HIST102Roadmap />

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react'
 import AppLayout from '../components/AppLayout'
 import LearningRoadmap from '../components/LearningRoadmap'
+import RoadmapCourseSelect from '../components/RoadmapCourseSelect'
+import { HOME_ROADMAP_PREVIEW } from '../data/homeRoadmapPreview'
 
 export default function HomePage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [homeRoadmapPath, setHomeRoadmapPath] = useState('/roadmap')
+  const roadmapPreview = HOME_ROADMAP_PREVIEW[homeRoadmapPath] ?? HOME_ROADMAP_PREVIEW['/roadmap']
 
   return (
     <AppLayout
@@ -45,18 +49,32 @@ export default function HomePage() {
         </section>
 
         <section className="rounded-2xl bg-white/90 dark:bg-slate-900/90 backdrop-blur-sm p-8 border-2 border-emerald-200/80 dark:border-emerald-800/40 shadow-soft">
-          <div className="flex items-center justify-between mb-6">
-            <div>
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between mb-5">
+            <div className="min-w-0">
               <h2 className="text-xl font-bold text-slate-900 dark:text-white font-display flex items-center gap-2">
-                <span className="material-symbols-outlined text-primary">route</span>
-                Financial Accounting Roadmap
+                <span className="material-symbols-outlined text-primary shrink-0">route</span>
+                <span className="break-words">{roadmapPreview.cardTitle}</span>
               </h2>
               <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-                6 learning outcomes · Personalized for you
+                {roadmapPreview.cardSubtitle}
               </p>
             </div>
+            <RoadmapCourseSelect
+              variant="page"
+              value={homeRoadmapPath}
+              onValueChange={setHomeRoadmapPath}
+              className="w-full lg:w-auto lg:max-w-md shrink-0"
+            />
           </div>
-          <LearningRoadmap compact showViewFullLink />
+          <LearningRoadmap
+            key={homeRoadmapPath}
+            compact
+            showViewFullLink
+            scrollable
+            outcomes={roadmapPreview.outcomes}
+            startHereTo={roadmapPreview.startHerePath}
+            viewFullTo={roadmapPreview.fullRoadmapPath}
+          />
         </section>
 
         <div className="grid grid-cols-1 xl:grid-cols-3 gap-8 min-w-0">

--- a/frontend/src/pages/IncomeStatementPage.tsx
+++ b/frontend/src/pages/IncomeStatementPage.tsx
@@ -1,10 +1,57 @@
 import { useState } from 'react'
 import AppLayout from '../components/AppLayout'
+import IncomeStatementPracticeCell, {
+  gradeCoffeeShopNetIncome,
+  gradeIncomeStatementFillBlank,
+  type IncomePracticeType,
+  type OpenPracticeFeedback,
+} from '../components/IncomeStatementPracticeCell'
 
 export default function IncomeStatementPage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [chatInput, setChatInput] = useState('')
+  const [practiceType, setPracticeType] = useState<IncomePracticeType>('open')
+  const [openFeedback, setOpenFeedback] = useState<OpenPracticeFeedback>('idle')
+  const [fillFeedback, setFillFeedback] = useState<OpenPracticeFeedback>('idle')
+  const [fillResetKey, setFillResetKey] = useState(0)
+
+  const resetFill = () => {
+    setFillFeedback('idle')
+    setFillResetKey((k) => k + 1)
+  }
+
+  const handlePracticeTypeChange = (t: IncomePracticeType) => {
+    setPracticeType(t)
+    setOpenFeedback('idle')
+    setFillFeedback('idle')
+    setFillResetKey((k) => k + 1)
+  }
+
+  const handleAsk = () => {
+    const text = chatInput.trim()
+    if (!text) return
+
+    if (practiceType === 'open') {
+      setOpenFeedback(gradeCoffeeShopNetIncome(text) ? 'correct' : 'incorrect')
+      setChatInput('')
+      return
+    }
+
+    if (practiceType === 'fill') {
+      setFillFeedback(gradeIncomeStatementFillBlank(text) ? 'correct' : 'incorrect')
+      setChatInput('')
+    }
+  }
+
+  const chatUsesSubmit = practiceType === 'open' || practiceType === 'fill'
+
+  const chatPlaceholder =
+    practiceType === 'open'
+      ? 'e.g. $30,000 or 30000 — what is the coffee shop’s net income?'
+      : practiceType === 'fill'
+        ? 'e.g. expenses — what word fills the blank?'
+        : 'Switch to Open-ended or Fill in the blank to submit an answer in chat.'
 
   return (
     <AppLayout
@@ -99,24 +146,17 @@ export default function IncomeStatementPage() {
             </div>
           </section>
 
-          <section className="rounded-2xl bg-gradient-to-br from-amber-50 to-emerald-50 dark:from-amber-950/30 dark:to-emerald-950/20 p-6 border-2 border-amber-200/80 dark:border-amber-800/40 shadow-soft">
-            <h3 className="text-lg font-bold text-slate-900 dark:text-white font-display mb-2 flex items-center gap-2">
-              <span className="material-symbols-outlined text-primary">edit</span>
-              Try it yourself
-            </h3>
-            <p className="text-slate-600 dark:text-slate-300 leading-relaxed mb-2">
-              Imagine a coffee shop makes <strong className="text-slate-900 dark:text-white">$200,000</strong> in revenue
-              this year. Their costs include:
-            </p>
-            <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 mb-4 space-y-1">
-              <li>Coffee beans and supplies: $60,000</li>
-              <li>Staff wages: $80,000</li>
-              <li>Rent and utilities: $30,000</li>
-            </ul>
-            <p className="text-slate-600 dark:text-slate-300 pb-2">
-              What's their net income? Ask a question in the chat below to check your answer.
-            </p>
-          </section>
+          <IncomeStatementPracticeCell
+            practiceType={practiceType}
+            onPracticeTypeChange={handlePracticeTypeChange}
+            openFeedback={openFeedback}
+            onResetOpenPractice={() => setOpenFeedback('idle')}
+            fillFeedback={fillFeedback}
+            fillResetKey={fillResetKey}
+            onFillResult={(r) => setFillFeedback(r)}
+            onResetFillPractice={resetFill}
+          />
+
           {/* Spacer to ensure content clears the fixed chat bar when scrolling */}
           <div aria-hidden="true" className="shrink-0" style={{ height: '100px' }} />
         </div>
@@ -132,12 +172,22 @@ export default function IncomeStatementPage() {
               type="text"
               value={chatInput}
               onChange={(e) => setChatInput(e.target.value)}
-              placeholder="Ask a question..."
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && chatUsesSubmit) handleAsk()
+              }}
+              placeholder={chatPlaceholder}
               className="flex-1 min-w-0 px-4 py-2.5 sm:py-3 rounded-xl border-2 border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 focus:border-primary focus:outline-none text-sm"
             />
             <button
               type="button"
-              className="rounded-xl bg-primary px-4 sm:px-6 py-2.5 sm:py-3 text-sm font-bold text-white hover:bg-primary-light transition-colors whitespace-nowrap"
+              onClick={handleAsk}
+              disabled={!chatUsesSubmit}
+              title={
+                chatUsesSubmit
+                  ? 'Submit your answer'
+                  : 'Switch to Open-ended or Fill in the blank to submit an answer here'
+              }
+              className="rounded-xl bg-primary px-4 sm:px-6 py-2.5 sm:py-3 text-sm font-bold text-white hover:bg-primary-light transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary"
             >
               Ask
             </button>

--- a/frontend/src/pages/MKTG440RoadmapPage.tsx
+++ b/frontend/src/pages/MKTG440RoadmapPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import AppLayout from '../components/AppLayout'
 import MKTG440Roadmap from '../components/MKTG440Roadmap'
+import RoadmapCourseSelect from '../components/RoadmapCourseSelect'
 
 export default function MKTG440RoadmapPage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -14,6 +15,7 @@ export default function MKTG440RoadmapPage() {
       onToggleSettings={() => setSettingsOpen(!settingsOpen)}
       title="Digital Marketing"
       description="6 learning outcomes · Personalized for you"
+      action={<RoadmapCourseSelect variant="header" />}
     >
       <div className="max-w-[800px] w-full min-w-0 mx-auto px-8 lg:px-12 py-8 lg:py-12">
         <MKTG440Roadmap />

--- a/frontend/src/pages/RoadmapPage.tsx
+++ b/frontend/src/pages/RoadmapPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import AppLayout from '../components/AppLayout'
 import LearningRoadmap from '../components/LearningRoadmap'
+import RoadmapCourseSelect from '../components/RoadmapCourseSelect'
 
 export default function RoadmapPage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -14,6 +15,7 @@ export default function RoadmapPage() {
       onToggleSettings={() => setSettingsOpen(!settingsOpen)}
       title="Financial Accounting"
       description="6 learning outcomes · Personalized for you"
+      action={<RoadmapCourseSelect variant="header" />}
     >
       <div className="max-w-[800px] w-full min-w-0 mx-auto px-8 lg:px-12 py-8 lg:py-12">
         <LearningRoadmap />


### PR DESCRIPTION
- Roadmap pages: course dropdown in PageHeader; home roadmap scroll shell
- Income statement: unified Try it yourself with question types (open, fill, flashcard, MCQ), chat grading for open/fill, LearningFillBlank drag-drop
- New components: RoadmapCourseSelect, IncomeStatementPracticeCell, LearningFlashcard, LearningMcq, LearningFillBlank; homeRoadmapPreview data

Made-with: Cursor